### PR TITLE
Fix/add missing key for prog type mapping

### DIFF
--- a/custom_components/voltalis/lib/infrastructure/dtos/voltalis_api/voltalis_device.py
+++ b/custom_components/voltalis/lib/infrastructure/dtos/voltalis_api/voltalis_device.py
@@ -56,6 +56,7 @@ VOLTALIS_DEVICE_PROG_TYPE_MAPPING = {
     VoltalisDeviceDtoProgTypeEnum.MANUAL: ProgramTypeEnum.MANUAL,
     VoltalisDeviceDtoProgTypeEnum.DEFAULT: ProgramTypeEnum.DEFAULT,
     VoltalisDeviceDtoProgTypeEnum.USER: ProgramTypeEnum.USER,
+    VoltalisDeviceDtoProgTypeEnum.QUICK: ProgramTypeEnum.QUICK,
 }
 
 

--- a/custom_components/voltalis/manifest.json
+++ b/custom_components/voltalis/manifest.json
@@ -8,5 +8,5 @@
   "issue_tracker": "https://github.com/ppaglier/voltalis-homeassistant/issues",
   "quality_scale": "silver",
   "requirements": ["aiohttp>=3.3.0,<4.0.0", "pydantic>=2.12.2,<3.0.0"],
-  "version": "0.6.3"
+  "version": "0.6.4"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "voltalis-homeassistant"
-version = "0.6.3"
+version = "0.6.4"
 description = "Voltalis integration in Home Assistant"
 authors = ["Pierre-Louis Pagliero"]
 license = "MIT"


### PR DESCRIPTION
This pull request updates the Voltalis Home Assistant integration to version 0.6.4 and adds support for a new program type. The most important changes are:

**Feature Addition:**

* Added support for the `QUICK` program type by mapping `VoltalisDeviceDtoProgTypeEnum.QUICK` to `ProgramTypeEnum.QUICK` in the device DTO enum mapping (`voltalis_device.py`).

**Version Bump:**

* Updated the version number to `0.6.4` in both `pyproject.toml` and `manifest.json` to reflect the new release. [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L3-R3) [[2]](diffhunk://#diff-9fe3dc8fcf88040f66c82aa2d9ecc4b43bda94f1fd3be1ffdf397276291d74c2L11-R11)